### PR TITLE
Add support for force pushing topic branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ request to the `remote` repository. [Pull request branches are
 read-only][read-only-pulls], so git-land exits with an error if invoked with a
 pull request number and this option specified.
 
+#### `-F, --no-force-push-topic`: do not force push rebased topic branch
+
+If this option is specified, `git-land` will not force push the rebased topic
+branch request to the `remote` repository, even if configured to do so by
+default.
+
 ## Installation
 
 ### NPM (recommended)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Note:
 ## Usage
 
 ```
-git land [<remote>] <pull request number>[:<target>]
-git land [<remote>] <branch>[:<target>]
+git land [options] [<remote>] <pull request number>[:<target>]
+git land [options] [<remote>] <branch>[:<target>]
 ```
 
 ### Examples
@@ -34,6 +34,15 @@ git land my-topic-branch
 git land origin 42:target-branch
 git land origin feature-branch:target-branch
 ```
+
+### Options
+
+#### `-f, --force-push-topic`: force push rebased topic branch
+
+If this option is specified, `git-land` will force push the rebased topic branch
+request to the `remote` repository. [Pull request branches are
+read-only][read-only-pulls], so git-land exits with an error if invoked with a
+pull request number and this option specified.
 
 ## Installation
 
@@ -88,6 +97,17 @@ target branch is specified. To use a different default target branch, set the
 git config git-land.target dev
 ```
 
+#### Whether to force push the topic branch
+
+By default, `git-land` does nothing with the topic branch after rebasing it
+locally. Specifying the `--force-push-topic` option overrides this behavior,
+force pushing the rebased topic branch to the target remote. To make this
+behavior the default, set the `git-land.force-push-topic` option to `true`:
+
+```sh
+git config git-land.force-push-topic true
+```
+
 ## Thanks
 
 Thanks to [@paulirish][paulirish] for [git-open](https://github.com/paulirish/git-open),
@@ -114,3 +134,5 @@ http://www.apache.org/licenses/LICENSE-2.0
 [reason]: https://github.com/reason-bv
 [taylormck]: https://github.com/taylormck
 [vvcephei]: https://github.com/vvcephei
+
+[read-only-pulls]: https://help.github.com/articles/checking-out-pull-requests-locally/#tips

--- a/git-land
+++ b/git-land
@@ -24,13 +24,17 @@ function exit_and_cleanup() {
 function usage() {
   echo "$1"
   echo ""
-  echo "Usage: git land [<remote>] <pull request number>[:<target branch>]"
-  echo "       git land [<remote>] <branch>[:<target branch>]"
+  echo "Usage: git land [options] [<remote>] <pull request number>[:<target branch>]"
+  echo "       git land [options] [<remote>] <branch>[:<target branch>]"
   echo ""
-  echo " <remote>: the remote repo (default: origin)"
-  echo " <pull request number>: a pull request to merge and close"
-  echo " <branch>: a branch to merge and close"
-  echo " <target branch>: the branch to merge to (default: master)"
+  echo "  <remote>: the remote repo (default: origin)"
+  echo "  <pull request number>: a pull request to merge and close"
+  echo "  <branch>: a branch to merge and close"
+  echo "  <target branch>: the branch to merge to (default: master)"
+  echo ""
+  echo "Options:"
+  echo "  -f, --force-push-topic: force push <branch> to <remote> after rebasing"
+  echo "  -F, --no-force-push-topic: do not force push <branch> to <remote> after rebasing"
   echo ""
   echo "Examples:"
   echo "  git land origin 23:master"
@@ -39,20 +43,6 @@ function usage() {
   echo ""
   exit_and_cleanup 1
 }
-
-
-args=()
-# Parse args
-while [[ $# > 0 ]]; do
-  arg="$1"
-
-  case $arg in
-    *)
-      args[${#args[@]}]=$arg
-      shift
-      ;;
-  esac
-done
 
 # set upstream remote, defaulting to origin
 remote=$(git config git-land.remote)
@@ -65,6 +55,32 @@ target_branch=$(git config git-land.target)
 if [ -z "$target_branch" ]; then
   target_branch='master'
 fi
+
+# are we configured to force push after rebasing?
+force_push_topic=$(git config --bool git-land.force-push-topic)
+[[ "$force_push_topic" = 'true' ]] \
+  && force_push_topic=true || force_push_topic=false
+
+args=()
+# Parse args
+while [[ $# > 0 ]]; do
+  arg="$1"
+
+  case $arg in
+    -f|--force-push-topic)
+      force_push_topic=true
+      shift
+      ;;
+    -F|--no-force-push-topic)
+      force_push_topic=false
+      shift
+      ;;
+    *)
+      args[${#args[@]}]=$arg
+      shift
+      ;;
+  esac
+done
 
 merge_branch=""
 
@@ -94,6 +110,10 @@ fi
 
 # set merge branch if merging a PR
 if [[ $merge_branch =~ ^[0-9]+$ ]]; then
+  if [ "$force_push_topic" = true ]; then
+    exit_and_cleanup 1 "Cannot force push a PR (https://help.github.com/articles/checking-out-pull-requests-locally/#tips)"
+  fi
+
   pr=$merge_branch
   merge_branch="$remote/pr/$pr"
 fi
@@ -123,6 +143,11 @@ if [ -n "$pr" ]; then
       echo "Could not append commit message tag to close #$pr"
     fi
   fi
+fi
+
+# optionally force push source branch to origin
+if [ "$force_push_topic" = true ]; then
+  git push -f $remote $merge_branch
 fi
 
 # merge the PR and push


### PR DESCRIPTION
To do so on a case-by-case basis, specify the `-f` or `--force-push-topic`
option. To make this the default, set the `force-push-topic` git config to
`true`. To override this new default on a case-by-case basis, specify the `-F`
or `--no-force-push-topic` option.

This fixes #17.

I'm hoping for review by @vvcephei, @reason-bv, or @rmurphey.

https://www.youtube.com/watch?v=2sromTpE4OE