### PR TITLE
Pre post hooks

### DIFF
--- a/git-land
+++ b/git-land
@@ -124,7 +124,7 @@ if [[ ! ($response = '' || $response =~ ^([yY][eE][sS]|[yY])$) ]]; then
 fi
 
 if [ -x "$project_root/.git/hooks/pre-land" ]; then
-  $project_root/.git/hooks/pre-land || \
+  $project_root/.git/hooks/pre-land $merge_branch $target_branch $remote || \
     exit_and_cleanup $? "pre-land hook returned a non-zero error code"
 fi
 
@@ -162,4 +162,10 @@ head=$(git rev-parse HEAD)
     exit_and_cleanup $? "Could not fast-forward merge $merge_branch into $target_branch"
 
 git push $remote $target_branch
+
+if [ -x "$project_root/.git/hooks/post-land" ]; then
+  $project_root/.git/hooks/post-land $merge_branch $target_branch $remote || \
+    exit_and_cleanup $? "post-land hook returned a non-zero error code"
+fi
+
 exit_and_cleanup $?

--- a/git-land
+++ b/git-land
@@ -123,6 +123,11 @@ if [[ ! ($response = '' || $response =~ ^([yY][eE][sS]|[yY])$) ]]; then
   exit_and_cleanup 1
 fi
 
+if [ -x "$project_root/.git/hooks/pre-land" ]; then
+  $project_root/.git/hooks/pre-land || \
+    exit_and_cleanup $? "pre-land hook returned a non-zero error code"
+fi
+
 # sync local $target_branch with latest on github
 (git checkout $target_branch && \
   git fetch $remote && \

--- a/test/git-land.bats
+++ b/test/git-land.bats
@@ -35,11 +35,11 @@ load setup
   [ $status -eq 0 ]
 
   run git log --pretty=format:"%s"
-  [[ "${lines[0]}" =~ 'second feature commit' ]]
-  [[ "${lines[1]}" =~ 'first feature commit' ]]
-  [[ "${lines[2]}" =~ 'third master commit' ]]
-  [[ "${lines[3]}" =~ 'second master commit' ]]
-  [[ "${lines[4]}" =~ 'first master commit' ]]
+  [ "${lines[0]}" = "wrote 'second feature commit' to feature.txt" ]
+  [ "${lines[1]}" = "wrote 'first feature commit' to feature.txt" ]
+  [ "${lines[2]}" = "wrote 'third master commit' to master.txt" ]
+  [ "${lines[3]}" = "wrote 'second master commit' to master.txt" ]
+  [ "${lines[4]}" = "wrote 'first master commit' to master.txt" ]
 }
 
 @test "'git land origin feature-branch:master' aborts and exits with an error if updating the target branch fails" {
@@ -97,10 +97,10 @@ load setup
   [ $status -eq 0 ]
 
   run git log --pretty=format:"%s"
-  [[ "${lines[0]}" =~ 'second feature commit' ]]
-  [[ "${lines[1]}" =~ 'first feature commit' ]]
-  [[ "${lines[2]}" =~ 'second master commit' ]]
-  [[ "${lines[3]}" =~ 'first master commit' ]]
+  [ "${lines[0]}" = "wrote 'second feature commit' to feature.txt" ]
+  [ "${lines[1]}" = "wrote 'first feature commit' to feature.txt" ]
+  [ "${lines[2]}" = "wrote 'second master commit' to master.txt" ]
+  [ "${lines[3]}" = "wrote 'first master commit' to master.txt" ]
 }
 
 @test "'git land origin feature-branch:master' pushes local master to origin" {

--- a/test/post-land-hook.bats
+++ b/test/post-land-hook.bats
@@ -1,0 +1,76 @@
+load setup
+
+# Running the hook
+# -----------------------------------------------------------------------------
+@test "if no hook defined, runs as expected" {
+  enter_repo "local"
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+}
+
+@test "if hook defined but not executable, does not run hook" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo "echo 'post-land'" > .git/hooks/post-land
+  chmod -x .git/hooks/post-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+  [[ ! "$output" =~ 'post-land' ]]
+}
+
+@test "if hook is defined and executable, runs the hook" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo "echo 'post-land'" > .git/hooks/post-land
+  chmod +x .git/hooks/post-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+  [[ "$output" =~ 'post-land' ]]
+}
+
+@test "hook is passed the source, target, and remote" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo 'echo "$1 $2 $3"' > .git/hooks/post-land
+  chmod +x .git/hooks/post-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+  [ "${lines[${#lines[@]} - 1]}" = "feature-branch master origin" ]
+}
+
+@test "hook runs after the land" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo 'echo `git log -1 --pretty=format:"%s"`' > .git/hooks/post-land
+  chmod +x .git/hooks/post-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+  [ "${lines[${#lines[@]} - 1]}" = "wrote 'second feature commit' to feature.txt" ]
+}
+
+# Exit conditions
+# -----------------------------------------------------------------------------
+@test "if hook exits with a non-zero exit code, exits with that code" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo "exit 42" > .git/hooks/post-land
+  chmod +x .git/hooks/post-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 42 ]
+}
+
+@test "if hook exits with a zero exit code, so does git-land" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo "exit 0" > .git/hooks/post-land
+  chmod +x .git/hooks/post-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+}

--- a/test/pre-land-hook.bats
+++ b/test/pre-land-hook.bats
@@ -1,0 +1,91 @@
+load setup
+
+# Running the hook
+# -----------------------------------------------------------------------------
+@test "if no hook defined, runs as expected" {
+  enter_repo "local"
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+}
+
+@test "if hook defined but not executable, does not run hook" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo "echo 'pre-land'" > .git/hooks/pre-land
+  chmod -x .git/hooks/pre-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+  [[ ! "$output" =~ 'pre-land' ]]
+}
+
+@test "if hook is defined and executable, runs the hook" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo "echo 'pre-land'" > .git/hooks/pre-land
+  chmod +x .git/hooks/pre-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+  [[ "$output" =~ 'pre-land' ]]
+}
+
+@test "hook is passed the source, target, and remote" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo 'echo "$1 $2 $3"' > .git/hooks/pre-land
+  chmod +x .git/hooks/pre-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "feature-branch master origin" ]
+}
+
+@test "hook runs before the land" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo 'echo `git log -1 --pretty=format:"%s"`' > .git/hooks/pre-land
+  chmod +x .git/hooks/pre-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "wrote 'second master commit' to master.txt" ]
+}
+
+# Exit conditions
+# -----------------------------------------------------------------------------
+@test "if hook exits with a non-zero exit code, exits with that code" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo "exit 42" > .git/hooks/pre-land
+  chmod +x .git/hooks/pre-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 42 ]
+}
+
+@test "if hook exits with a zero exit code, performs the land" {
+  enter_repo "local"
+  mkdir -p .git/hooks
+  echo "exit 0" > .git/hooks/pre-land
+  chmod +x .git/hooks/pre-land
+
+  run bash -c "yes | git land origin feature-branch:master"
+  [ $status -eq 0 ]
+
+  # feature branch landed to local master
+  run git log --pretty=format:"%s"
+  [ "${lines[0]}" = "wrote 'second feature commit' to feature.txt" ]
+  [ "${lines[1]}" = "wrote 'first feature commit' to feature.txt" ]
+  [ "${lines[2]}" = "wrote 'second master commit' to master.txt" ]
+  [ "${lines[3]}" = "wrote 'first master commit' to master.txt" ]
+
+  # origin updated
+  local_log=`git log --pretty=format:"%h %s"`
+
+  enter_repo "origin"
+  origin_log=`git log --pretty=format:"%h %s"`
+
+  [ "$origin_log" = "$local_log" ]
+}

--- a/test/setup.bash
+++ b/test/setup.bash
@@ -73,3 +73,8 @@ function write_commit() {
 function enter_repo() {
   cd $fixture_root/$1
 }
+
+function contains() {
+  [[ "$1" =~ "$2" ]] || \
+    echo "expected '$1' to contain '$2'" >&2 && exit 1
+}

--- a/test/setup.bash
+++ b/test/setup.bash
@@ -73,8 +73,3 @@ function write_commit() {
 function enter_repo() {
   cd $fixture_root/$1
 }
-
-function contains() {
-  [[ "$1" =~ "$2" ]] || \
-    echo "expected '$1' to contain '$2'" >&2 && exit 1
-}


### PR DESCRIPTION
We now check `.git/hooks` for two executable files: `pre-land` and `post-land`.

If `pre-land` is present and executable, it is run before landing begins. If it
returns a non-zero exit code, an error is printed and `git-land` exits with that
error code. Otherwise, landing proceeds normally.

If `post-land` is present and executable, it is run after landing completes
successfully. If it returns a non-zero exit code, an error is printed and
`git-land` exits with that error code.

In each case, the hook is passed the following arguments, in order:
- the source branch
- the target branch
- the target remote

---

The first commit fixes a bug in the tests.