### PR TITLE
Check for push failure before running post-land hook

### DIFF
--- a/git-land
+++ b/git-land
@@ -161,7 +161,8 @@ head=$(git rev-parse HEAD)
   git merge --ff-only $head) || \
     exit_and_cleanup $? "Could not fast-forward merge $merge_branch into $target_branch"
 
-git push $remote $target_branch
+git push $remote $target_branch || \
+  exit_and_cleanup $? "Could not push $target_branch to $remote"
 
 if [ -x "$project_root/.git/hooks/post-land" ]; then
   $project_root/.git/hooks/post-land $merge_branch $target_branch $remote || \


### PR DESCRIPTION
We did not check that the final push of the target branch actually succeeds. As
a result, we execute the post-land hook even if the push fails. So, check the
exit code and exit with an error if it's non-zero.

[fix #35]

I did not add a test, as doing so would require mocking `git push`, and I don't want to block this bug fix on that.
